### PR TITLE
fix: Correct inverted AR marker direction

### DIFF
--- a/script.js
+++ b/script.js
@@ -111,8 +111,11 @@ document.addEventListener('DOMContentLoaded', () => {
 
         if (window.DeviceOrientationEvent) {
             window.addEventListener('deviceorientation', (event) => {
-                // alpha: rotation around z-axis
-                deviceOrientation = event.alpha;
+                let heading = event.alpha;
+                if (typeof event.webkitCompassHeading !== 'undefined') {
+                    heading = event.webkitCompassHeading; // More reliable on iOS
+                }
+                deviceOrientation = heading;
                 updateARView();
             });
         } else {
@@ -170,7 +173,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const screenWidth = window.innerWidth;
 
         if (Math.abs(angleDifference) < fov / 2) {
-            const xPosition = (angleDifference / (fov / 2)) * (screenWidth / 2) + (screenWidth / 2);
+            const xPosition = (-angleDifference / (fov / 2)) * (screenWidth / 2) + (screenWidth / 2);
             arMarker.style.left = `${xPosition}px`;
             arMarker.style.display = 'block';
         } else {


### PR DESCRIPTION
This commit fixes a critical bug where the AR marker's on-screen position was inverted, causing it to point away from the target location instead of towards it.

The fix involves two changes:
1.  The horizontal positioning logic in `updateARView` has been corrected by inverting the sign of the angle difference in the calculation.
2.  The `deviceorientation` event handler has been improved to use `event.webkitCompassHeading` when available, providing more reliable compass data on iOS devices and improving overall accuracy.