### PR TITLE
fix: Resolve AR orientation issue by removing double correction

### DIFF
--- a/js/ar-controller.js
+++ b/js/ar-controller.js
@@ -19,7 +19,6 @@ export function initBabylonScene(canvas) {
 
     // Create a camera that we will control manually
     arCamera = new BABYLON.DeviceOrientationCamera("arCamera", new BABYLON.Vector3(0, 0, 0), scene);
-    arCamera.rotation.y = Math.PI; // Add a 180-degree rotation to fix orientation
     arCamera.attachControl(canvas, true);
 
 

--- a/js/sensor-controller.js
+++ b/js/sensor-controller.js
@@ -76,7 +76,7 @@ export function startSensors(appState, onUpdate) {
         appState.diagnosticData.trueHeading = smoothedHeading.toFixed(2);
 
         const screenOrientationAngle = screen.orientation.angle || 0;
-        appState.deviceOrientation = (smoothedHeading - screenOrientationAngle + 360) % 360;
+        appState.deviceOrientation = smoothedHeading;
         appState.devicePitch = pitch;
         appState.diagnosticData.screenCorrectedHeading = appState.deviceOrientation.toFixed(2);
         appState.diagnosticData.pitch = appState.devicePitch.toFixed(2);


### PR DESCRIPTION
This commit fixes a persistent issue with the AR camera's orientation being incorrect. The root cause was determined to be a "double correction" of the device's orientation.

The code was manually adjusting the sensor heading based on the screen's orientation angle. However, the `DeviceOrientationCamera` from Babylon.js, which was recently implemented, also performs this correction internally. This resulted in the correction being applied twice, leading to unpredictable orientation errors.

This commit removes the manual screen orientation adjustment from `js/sensor-controller.js`. The `DeviceOrientationCamera` is now solely responsible for interpreting and applying the device orientation, which should resolve the issue and correctly align the AR view.